### PR TITLE
Add -std=legacy for newer gfortan versions

### DIFF
--- a/makefile
+++ b/makefile
@@ -8,7 +8,7 @@ INCPATH = $(SOURCEDIR)/inc
 
 OBJ_PATH = $(PWD)/obj/
 
-FFLAGS 	= -fno-automatic -fno-f2c -O2 -g  -I$(INCPATH)
+FFLAGS 	= -std=legacy -fno-automatic -fno-f2c -O2 -g  -I$(INCPATH)
 
 DIRS	 =	$(SOURCEDIR)/int:\
 		$(SOURCEDIR)/main:\


### PR DESCRIPTION
With new versions of gfortran (e.g. 9.3.1) the code does not compile unless the standard is set correctly.

Please check whether this doesn't break the build with older compilers.